### PR TITLE
Numbers are shown in two different formats, depending on their value, for no...

### DIFF
--- a/lib/flt/num.rb
+++ b/lib/flt/num.rb
@@ -3893,7 +3893,7 @@ class Num < Numeric
       end
     else
       # TODO: DRY (this code is duplicated in num_class#format)
-      if exp<=0 && leftdigits>-6
+      if exp<=0
         dotplace = leftdigits
       elsif !eng
         dotplace = 1


### PR DESCRIPTION
... obvious reason: compare Flt::DecNum('0.000001') and Flt::DecNum('0.0000001'). This change fixes that problem.