### PR TITLE
Fix frozen string exception

### DIFF
--- a/lib/flt/num.rb
+++ b/lib/flt/num.rb
@@ -2907,7 +2907,7 @@ class Num < Numeric
   end
 
   # Digits of the significand as an array of integers
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.4.0')
     def digits
       @coeff.is_a?(Integer) ? @coeff.digits(num_class.radix).reverse! : []
     end


### PR DESCRIPTION
I had an issue on ruby 1.9.3 `strip!': can't modify frozen String (RuntimeError)` 

This happens because the version number passed in is frozen and the downstream code mutates it, causing an exception. 